### PR TITLE
SwitchParameter -AsPlainText

### DIFF
--- a/ConfluencePS/Public/ConvertTo-StorageFormat.ps1
+++ b/ConfluencePS/Public/ConvertTo-StorageFormat.ps1
@@ -18,7 +18,8 @@ function ConvertTo-StorageFormat {
             Mandatory = $true,
             ValueFromPipeline = $true
         )]
-        [string[]]$Content
+        [string[]]$Content,
+        [System.Management.Automation.SwitchParameter]$AsPlainText
     )
 
     BEGIN {
@@ -28,6 +29,27 @@ function ConvertTo-StorageFormat {
     PROCESS {
         Write-Debug "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
         Write-Debug "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
+
+        if ($AsPlainText)
+        {
+            Write-Verbose "[$($MyInvocation.MyCommand.Name)] Replace special chars with ascii code"
+            [System.Collections.Hashtable]$SpecialChars = @{
+                '#' = '&#35;'
+                '@' = '&#64;'
+                '[' = '&#91;'
+                ']' = '&#93;'
+                '{' = '&#123;'
+                '}' = '&#1225;'
+            }
+
+            foreach ($Key in $SpecialChars.Keys)
+            {
+                for ($i = 0; $i -lt $Content.Count; $i ++)
+                {
+                    $Content[$i] = $Content[$i].Replace($Key, $SpecialChars.$Key)
+                }
+            }
+        }
 
         $iwParameters = Copy-CommonParameter -InputObject $PSBoundParameters
         $iwParameters['Uri'] = "$ApiUri/contentbody/convert/storage"


### PR DESCRIPTION
Added switch parameter '-AsPlainText' to replace chars which confluence would try to convert to macros.

<!-- markdownlint-disable MD002 -->
<!-- markdownlint-disable MD041 -->
<!-- Provide a general summary of your changes in the Title above -->

### Description

<!-- Describe your changes in detail -->

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here as follows: -->
<!-- closes #1, closes #2, ... -->

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have added Pester Tests that describe what my changes should do.
- [ ] I have updated the documentation accordingly.
